### PR TITLE
Add path comments to log-agent scripts

### DIFF
--- a/src/scripts/log-agent/cli.ts
+++ b/src/scripts/log-agent/cli.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/cli.ts
 import axios from 'axios';
 import { program } from 'commander';
 import readline from 'readline';

--- a/src/scripts/log-agent/config.ts
+++ b/src/scripts/log-agent/config.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/config.ts
 import dotenv from 'dotenv';
 
 // Define LogAgentConfig interface directly in this file to avoid import issues

--- a/src/scripts/log-agent/integration.ts
+++ b/src/scripts/log-agent/integration.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/integration.ts
 import winston from 'winston';
 import axios from 'axios';
 import { createLogAgentTransport } from './logger-transport.js';

--- a/src/scripts/log-agent/logger-transport.ts
+++ b/src/scripts/log-agent/logger-transport.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/logger-transport.ts
 import Transport from 'winston-transport';
 import axios from 'axios';
 import { LogEntry, LogBatch } from './types.js';

--- a/src/scripts/log-agent/services/notification.service.ts
+++ b/src/scripts/log-agent/services/notification.service.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/services/notification.service.ts
 import axios from 'axios';
 import { config } from '../config.js';
 import { Issue, NotificationPayload } from '../types.js';

--- a/src/scripts/log-agent/services/openai.service.ts
+++ b/src/scripts/log-agent/services/openai.service.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/services/openai.service.ts
 import OpenAI from 'openai';
 import CircuitBreaker from 'opossum';
 import { config } from '../config.js';

--- a/src/scripts/log-agent/services/pattern.service.ts
+++ b/src/scripts/log-agent/services/pattern.service.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/services/pattern.service.ts
 import { LogEntry, LogPattern, Issue } from '../types.js';
 
 /**

--- a/src/scripts/log-agent/services/redis.service.ts
+++ b/src/scripts/log-agent/services/redis.service.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/services/redis.service.ts
 import { createClient, type RedisClientType } from 'redis';
 import { config, redisKeys, generateRunId } from '../config.js';
 import { LogEntry, Issue, LogBatch } from '../types.js';

--- a/src/scripts/log-agent/services/worker.service.ts
+++ b/src/scripts/log-agent/services/worker.service.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/services/worker.service.ts
 import { Queue, Worker, ConnectionOptions, QueueEvents } from 'bullmq';
 import { config } from '../config.js';
 import { LogBatch, LogEntry, Issue } from '../types.js';

--- a/src/scripts/log-agent/types.ts
+++ b/src/scripts/log-agent/types.ts
@@ -1,3 +1,4 @@
+// src/scripts/log-agent/types.ts
 /**
  * Core types for the Log Agent service
  */


### PR DESCRIPTION
## Summary
- add relative path comments to log-agent `.ts` scripts and services

## Testing
- `npm test` *(fails: dotenv not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: TypeScript errors in repository)*