### PR TITLE
Add log agent endpoint tests

### DIFF
--- a/src/scripts/log-agent/__tests__/ingest.test.ts
+++ b/src/scripts/log-agent/__tests__/ingest.test.ts
@@ -1,0 +1,66 @@
+// src/scripts/log-agent/__tests__/ingest.test.ts
+import { describe, it, expect, beforeAll, afterAll, jest } from '@jest/globals';
+import { app } from '../server';
+import type { LogBatch } from '../types';
+import http from 'http';
+
+// Mock worker service
+jest.mock('../services/worker.service.js', () => ({
+  workerService: {
+    addLogBatch: jest.fn().mockResolvedValue('job-123'),
+    getMetrics: jest.fn(),
+  },
+}));
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const { port } = server.address() as any;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+describe('/ingest endpoint', () => {
+  it('queues log batch and returns 202', async () => {
+    const batch: LogBatch = {
+      runId: 'test-run',
+      source: 'test-source',
+      entries: [
+        {
+          timestamp: new Date().toISOString(),
+          level: 'info',
+          message: 'hello world',
+          runId: 'test-run',
+          source: 'test-source',
+        },
+      ],
+    };
+
+    const res = await fetch(`${baseUrl}/ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(batch),
+    });
+
+    expect(res.status).toBe(202);
+    const json = await res.json();
+    expect(json.jobId).toBe('job-123');
+    expect(json.runId).toBe('test-run');
+  });
+
+  it('rejects invalid batch', async () => {
+    const res = await fetch(`${baseUrl}/ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/scripts/log-agent/__tests__/qna.test.ts
+++ b/src/scripts/log-agent/__tests__/qna.test.ts
@@ -1,0 +1,91 @@
+// src/scripts/log-agent/__tests__/qna.test.ts
+import { describe, it, expect, beforeAll, afterAll, jest, beforeEach } from '@jest/globals';
+import { app } from '../server';
+import type { LogEntry } from '../types';
+import http from 'http';
+
+const mockGetLogs = jest.fn();
+const mockAnalyzeLogs = jest.fn();
+
+jest.mock('../services/redis.service.js', () => ({
+  redisService: {
+    getLogs: mockGetLogs,
+    getLatestRun: jest.fn(),
+  },
+}));
+
+jest.mock('../services/openai.service.js', () => ({
+  openaiService: {
+    analyzeLogs: mockAnalyzeLogs,
+    getMetrics: jest.fn(),
+    resetMetrics: jest.fn(),
+  },
+}));
+
+jest.mock('../services/worker.service.js', () => ({
+  workerService: {
+    getMetrics: jest.fn(),
+    addLogBatch: jest.fn(),
+  },
+}));
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const { port } = server.address() as any;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('/qna endpoint', () => {
+  it('returns analysis for provided logs', async () => {
+    const logs: LogEntry[] = [
+      {
+        timestamp: new Date().toISOString(),
+        level: 'info',
+        message: 'hello',
+        runId: 'abc',
+        source: 'test',
+      },
+    ];
+    mockGetLogs.mockResolvedValue({ logs, total: logs.length });
+    mockAnalyzeLogs.mockResolvedValue({
+      answer: 'analysis',
+      runId: 'abc',
+      tokenUsage: { prompt: 0, completion: 0, total: 0 },
+    });
+
+    const res = await fetch(`${baseUrl}/qna`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: 'what', runId: 'abc' }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.answer).toBe('analysis');
+    expect(json.logCount).toBe(1);
+  });
+
+  it('returns 404 when no logs are found', async () => {
+    mockGetLogs.mockResolvedValue({ logs: [], total: 0 });
+
+    const res = await fetch(`${baseUrl}/qna`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: 'test', runId: 'abc' }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/scripts/log-agent/server.ts
+++ b/src/scripts/log-agent/server.ts
@@ -13,7 +13,7 @@ import { LogBatch, LogEntry, QnaRequest, ClearRequest } from './types.js';
 dotenv.config();
 
 // Create Express app
-const app = express();
+export const app = express();
 
 // Setup Prometheus metrics
 const metricsMiddleware = promBundle.default({
@@ -286,10 +286,12 @@ const gracefulShutdown = async () => {
 process.on('SIGTERM', gracefulShutdown);
 process.on('SIGINT', gracefulShutdown);
 
-// Start server
-const PORT = config.port;
-app.listen(PORT, () => {
-  console.info(`✅ Log Agent server running on port ${PORT}`);
-  console.info(`📊 Metrics available at http://localhost:${PORT}/metrics`);
-  console.info(`🚦 Health check at http://localhost:${PORT}/health`);
-}); 
+// Start server if not running under Jest
+if (!process.env.JEST_WORKER_ID) {
+  const PORT = config.port;
+  app.listen(PORT, () => {
+    console.info(`✅ Log Agent server running on port ${PORT}`);
+    console.info(`📊 Metrics available at http://localhost:${PORT}/metrics`);
+    console.info(`🚦 Health check at http://localhost:${PORT}/health`);
+  });
+}


### PR DESCRIPTION
## Summary
- export `app` from log-agent server
- avoid starting log-agent server under Jest
- add tests for `/ingest` and `/qna` endpoints

## Testing
- `npm test` *(fails: `dotenv: not found`)*
- `npm run lint` *(fails: `next: not found`)*
- `npm run type-check` *(fails: missing script)*