### PR TITLE
Add path comments to agents

### DIFF
--- a/src/server/agents/__tests__/adb-agent.test.ts
+++ b/src/server/agents/__tests__/adb-agent.test.ts
@@ -1,3 +1,4 @@
+// src/server/agents/__tests__/adb-agent.test.ts
 import { ADBAgent } from "../adb-agent";
 import { BaseAgent, type AgentMessage } from "../base-agent";
 import { taskManager } from "~/server/services/a2a/taskManager.service";

--- a/src/server/agents/__tests__/error-fixer-agent.test.ts
+++ b/src/server/agents/__tests__/error-fixer-agent.test.ts
@@ -1,3 +1,4 @@
+// src/server/agents/__tests__/error-fixer-agent.test.ts
 import { ErrorFixerAgent, type ErrorFixerAgentParams } from '../error-fixer-agent';
 import { BaseAgent, type AgentMessage } from '../base-agent';
 import { taskManager } from '~/server/services/a2a/taskManager.service';

--- a/src/server/agents/__tests__/message-bus.service.test.ts
+++ b/src/server/agents/__tests__/message-bus.service.test.ts
@@ -1,3 +1,4 @@
+// src/server/agents/__tests__/message-bus.service.test.ts
 import { MessageBus, messageBus } from "../message-bus";
 import { BaseAgent, type AgentMessage } from "../base-agent";
 import { db } from "~/server/db";

--- a/src/server/agents/__tests__/r2-storage-agent.test.ts
+++ b/src/server/agents/__tests__/r2-storage-agent.test.ts
@@ -1,3 +1,4 @@
+// src/server/agents/__tests__/r2-storage-agent.test.ts
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { R2StorageAgent } from '../r2-storage-agent';
 import { BaseAgent, type AgentMessage } from '../base-agent';

--- a/src/server/agents/__tests__/ui-agent.test.ts
+++ b/src/server/agents/__tests__/ui-agent.test.ts
@@ -1,3 +1,4 @@
+// src/server/agents/__tests__/ui-agent.test.ts
 import { UIAgent } from "../ui-agent";
 import { BaseAgent, type AgentMessage } from "../base-agent";
 import { taskManager } from "~/server/services/a2a/taskManager.service";

--- a/src/server/agents/base-agent.ts
+++ b/src/server/agents/base-agent.ts
@@ -1,3 +1,4 @@
+// src/server/agents/base-agent.ts
 import { db } from "~/server/db";
 import { agentMessages, customComponentJobs } from "~/server/db/schema";
 import { eq } from "drizzle-orm";

--- a/src/server/agents/builder-agent.ts
+++ b/src/server/agents/builder-agent.ts
@@ -1,3 +1,4 @@
+// src/server/agents/builder-agent.ts
 import { BaseAgent, type AgentMessage } from "./base-agent";
 import { taskManager } from "~/server/services/a2a/taskManager.service";
 import type { TaskManager } from "~/server/services/a2a/taskManager.service";


### PR DESCRIPTION
## Summary
- prepend path comments for server agent modules
- ensure agent test files start with path comments

## Testing
- `npm test` *(fails: dotenv not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: TS errors in repo)*