### PR TITLE
Fix ScenePlannerAgent patch activation

### DIFF
--- a/scripts/startup-with-a2a.sh
+++ b/scripts/startup-with-a2a.sh
@@ -22,6 +22,8 @@ export TASK_PROCESSOR_HEARTBEAT_INTERVAL=5000
 
 # Enable Message Bus architecture
 export USE_MESSAGE_BUS=true
+# Enable ScenePlannerAgent patch so it registers correctly
+export APPLY_SCENE_PLANNER_PATCH=true
 
 # Set environment variables for stable development experience
 export WATCHPACK_POLLING=true


### PR DESCRIPTION
## Summary
- enable APPLY_SCENE_PLANNER_PATCH in `startup-with-a2a.sh`

## Testing
- `npm test` *(fails: "You are trying to import a file after the Jest environment has been torn down")*
- `npm run lint` *(fails with many lint errors)*
- `npm run typecheck` *(fails with TypeScript errors)*