### PR TITLE
Add project 1 ticket analysis

### DIFF
--- a/memory-bank/sprints/sprint24/project1-ticket-breakdown.md
+++ b/memory-bank/sprints/sprint24/project1-ticket-breakdown.md
@@ -1,0 +1,113 @@
+// /memory-bank/sprints/sprint24/project1-ticket-breakdown.md
+# Project 1 - Detailed Ticket Breakdown for Sprint 24
+
+This document expands the Project 1 tickets defined in `tickets.md`. It provides step-by-step guidance, key considerations, and testing recommendations so the team can implement each task with minimal uncertainty.
+
+## BAZAAR-243: Refactor chatOrchestration.service.ts
+
+### Goal
+Break the large `chatOrchestration.service.ts` into composable services while keeping the existing API surface for callers.
+
+### Implementation Outline
+- **Extract LLM communication**
+  - Create `LLMService` (`src/server/services/llm.service.ts`) handling prompt assembly and streaming interaction with OpenAI.
+  - Move token accounting and model selection logic here.
+- **Introduce ToolExecutionService**
+  - Dedicated module responsible for executing tool calls returned by the LLM.
+  - Should dispatch to existing helpers such as `componentGenerator.service.ts` and `scenePlanner.service.ts`.
+- **Separate orchestration flows**
+  - Scene planning and component generation should become distinct functions invoked by the main service.
+  - `processUserMessage` becomes a thin coordinator calling `LLMService` and `ToolExecutionService`.
+- **Improve error handling**
+  - Wrap each stage in `try/catch` and emit structured errors via SSE.
+  - Use typed error classes to distinguish user facing errors from system errors.
+- **Maintain backward compatibility**
+  - Keep exported function names and parameters the same.
+  - Add deprecation comments for any internal helpers that will be removed later.
+
+### Key Considerations & Trade-offs
+- Smaller services improve testability but introduce more files and dependency wiring.
+- Streaming responses must remain uninterrupted; carefully manage async flows when splitting modules.
+- Ensure database transactions remain consistent across new service boundaries.
+
+### Testing Approach
+- Unit tests for `LLMService` mocking OpenAI responses.
+- Unit tests for `ToolExecutionService` verifying correct dispatch to tools.
+- Integration test for `processUserMessage` covering streaming flow and SSE emission.
+- Regression tests to prove existing consumers (e.g., `chat.sendMessage`) behave identically.
+
+### Affected Areas
+- `src/server/services/chatOrchestration.service.ts`
+- New files under `src/server/services/`
+- Test suites under `src/server/services/__tests__/`
+
+## BAZAAR-244: Implement error recovery for component generation pipeline
+
+### Goal
+Allow component generation to resume from the last successful step after a failure.
+
+### Implementation Outline
+- **Persist generation stages**
+  - Extend `customComponentJobs` table with fields such as `lastSuccessfulStep`, `errorContext`, and timestamps for each step.
+  - Update `componentGenerator.service.ts` to write progress after code generation, build, and validation steps.
+- **Retry and backoff logic**
+  - Add a `retryCount` and `nextRetryAt` field to the job record.
+  - Implement exponential backoff when reprocessing failed jobs.
+- **Manual resume capability**
+  - Expose a procedure (e.g., `customComponent.resumeJob(jobId)`) that loads state and continues from the recorded step.
+  - Emit detailed SSE messages so the UI can surface recovery options.
+- **Detailed error context**
+  - Capture worker errors, stack traces, and LLM responses for troubleshooting.
+  - Store this context in a structured JSON column.
+
+### Key Considerations & Trade-offs
+- Additional DB writes may impact performance; ensure writes are batched or transactionally safe.
+- Consider how long intermediate build artifacts should persist (cleanup policy).
+- Backward compatibility requires a migration script for the new columns with defaults.
+
+### Testing Approach
+- Unit tests simulating failures at each stage and verifying job status updates.
+- Integration test running the full pipeline with induced failures and a manual resume.
+- Tests for retry backoff timing using mocked timers.
+
+### Affected Areas
+- `src/server/services/componentGenerator.service.ts`
+- Worker scripts in `src/server/workers/`
+- Database schema and migration files
+
+## BAZAAR-245: Enhance real-time feedback during processing
+
+### Goal
+Provide users with clearer insight into long running operations by emitting more granular SSE events and supporting reconnection.
+
+### Implementation Outline
+- **Fine-grained progress events**
+  - Define consistent event types (e.g., `component.build.start`, `component.build.complete`).
+  - Emit events from `componentGenerator.service.ts` and related workers at each significant step.
+- **Reconnection support**
+  - Persist the last sent event ID for each SSE stream.
+  - When a client reconnects with `Last-Event-ID`, resume emitting from the next event.
+- **UI updates**
+  - Update the editor interface to show current stage, percentage complete, and allow retry when failures occur.
+  - Provide visual indicators (spinners, progress bars) tied to the new events.
+- **Integration tests for connection interruptions**
+  - Simulate network drops in tests to ensure the client receives remaining events after reconnecting.
+
+### Key Considerations & Trade-offs
+- More frequent events increase network chatter but greatly improve perceived responsiveness.
+- Reconnection logic must avoid duplicate side effects; ensure idempotent handlers on the client.
+
+### Testing Approach
+- Unit tests for the SSE manager verifying event buffering and resend on reconnect.
+- Integration tests using mocked EventSource clients to mimic disconnects.
+- UI tests validating progress updates in the browser (can be done with Playwright or Cypress in the future).
+
+### Affected Areas
+- `src/server/services/eventBuffer.service.ts`
+- `src/server/services/componentGenerator.service.ts`
+- Client-side SSE handling in editor components
+
+---
+
+With these detailed tasks, the team can systematically tackle Project 1 improvements in Sprint 24. Each ticket now includes concrete steps, considerations, and testing plans to reduce ambiguity and accelerate implementation.
+

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -175,6 +175,9 @@ export const customComponentJobs = createTable(
     outputUrl: d.text(), // URL to the compiled JS hosted on R2
     errorMessage: d.text(), // Error message if compilation failed
     retryCount: d.integer().default(0).notNull(), // Number of retry attempts
+    lastSuccessfulStep: d.varchar('last_successful_step', { length: 50 }),
+    nextRetryAt: d.timestamp('next_retry_at', { withTimezone: true }),
+    errorContext: d.jsonb('error_context'),
     // A2A protocol support fields
     taskId: d.text('task_id'), // A2A task ID
     internalStatus: d.varchar('internal_status', { length: 50 }), // For internal tracking
@@ -371,8 +374,15 @@ export const agentMessagesIndexes = {
 
 // Add history field to customComponentJobs to support A2A protocol task history
 export const customComponentJobsUpdate = sql`
-  ALTER TABLE "bazaar-vid_custom_component_job" 
+  ALTER TABLE "bazaar-vid_custom_component_job"
   ADD COLUMN IF NOT EXISTS "history" JSONB
+`;
+
+export const customComponentJobsRecoveryUpdate = sql`
+  ALTER TABLE "bazaar-vid_custom_component_job"
+  ADD COLUMN IF NOT EXISTS "last_successful_step" varchar(50),
+  ADD COLUMN IF NOT EXISTS "next_retry_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "error_context" jsonb
 `;
 
 // --- Component Test Cases table ---

--- a/src/server/services/__tests__/llm.service.test.ts
+++ b/src/server/services/__tests__/llm.service.test.ts
@@ -1,0 +1,18 @@
+// src/server/services/__tests__/llm.service.test.ts
+import { describe, it, expect } from '@jest/globals';
+import { LLMService } from '../llm.service';
+
+const mockCreate = jest.fn();
+const mockClient: any = {
+  chat: { completions: { create: mockCreate } }
+};
+
+describe('LLMService', () => {
+  it('delegates to OpenAI client', async () => {
+    mockCreate.mockResolvedValue('stream');
+    const svc = new LLMService(mockClient);
+    const stream = await svc.streamChat([]);
+    expect(stream).toBe('stream');
+    expect(mockCreate).toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/toolExecution.service.test.ts
+++ b/src/server/services/__tests__/toolExecution.service.test.ts
@@ -1,0 +1,15 @@
+// src/server/services/__tests__/toolExecution.service.test.ts
+import { describe, it, expect, jest } from '@jest/globals';
+import { handleApplyJsonPatch } from '../toolExecution.service';
+import { db, patches } from '~/server/db';
+
+jest.mock('~/server/db', () => ({
+  db: { insert: jest.fn().mockReturnValue({ values: jest.fn().mockReturnValue({}) }) },
+  patches: {}
+}));
+
+describe('handleApplyJsonPatch', () => {
+  it('throws on invalid ops', async () => {
+    await expect(handleApplyJsonPatch('p', [] as any)).rejects.toThrow();
+  });
+});

--- a/src/server/services/llm.service.ts
+++ b/src/server/services/llm.service.ts
@@ -1,0 +1,20 @@
+// src/server/services/llm.service.ts
+import type { OpenAI } from "openai";
+import { CHAT_TOOLS } from "~/server/lib/openai/tools";
+
+export class LLMService {
+  private client: OpenAI;
+
+  constructor(client: OpenAI) {
+    this.client = client;
+  }
+
+  async streamChat(messages: OpenAI.Chat.ChatCompletionMessageParam[]) {
+    return this.client.chat.completions.create({
+      model: "o4-mini",
+      messages,
+      stream: true,
+      tools: CHAT_TOOLS,
+    });
+  }
+}

--- a/src/server/services/toolExecution.service.ts
+++ b/src/server/services/toolExecution.service.ts
@@ -1,0 +1,149 @@
+// src/server/services/toolExecution.service.ts
+import { TRPCError } from "@trpc/server";
+import { randomUUID } from "crypto";
+import type { Subject } from "rxjs";
+import { type Operation } from "fast-json-patch";
+import { db } from "~/server/db";
+import { patches } from "~/server/db/schema";
+import { handleScenePlan } from "./scenePlanner.service";
+import { generateComponent } from "./componentGenerator.service";
+import type { InputProps } from "~/types/input-props";
+import type { JsonPatch } from "~/types/json-patch";
+import type { ToolCallAccumulator } from "~/types/chat";
+import { chatLogger } from "~/lib/logger";
+
+interface ToolCallResponse {
+  message: string;
+  patches?: Operation[];
+}
+
+export async function handleApplyJsonPatch(
+  projectId: string,
+  operations: Operation[],
+  explanation?: string
+): Promise<ToolCallResponse> {
+  const messageId = "apply-json-patch";
+
+  if (!operations || !Array.isArray(operations) || operations.length === 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid or empty patch operations",
+    });
+  }
+
+  chatLogger.tool(messageId, "applyJsonPatch", `Applying ${operations.length} JSON patch operations to project ${projectId}`);
+
+  await db.insert(patches).values({
+    projectId,
+    patch: operations as JsonPatch,
+  });
+
+  return {
+    message: explanation || `Applied ${operations.length} patch operations to your video.`,
+    patches: operations,
+  };
+}
+
+export async function handleGenerateComponent(
+  projectId: string,
+  userId: string,
+  effectDescription: string,
+  assistantMessageId: string
+): Promise<ToolCallResponse> {
+  const startTime = Date.now();
+  const messageId = assistantMessageId || "generate-component";
+
+  if (!effectDescription || typeof effectDescription !== "string") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Missing or invalid effect description",
+    });
+  }
+
+  chatLogger.tool(messageId, "generateRemotionComponent", `Generating component for project ${projectId} with description: ${effectDescription}`);
+
+  const tempSceneId = randomUUID();
+  const briefParams = {
+    projectId,
+    sceneId: tempSceneId,
+    scenePurpose: effectDescription,
+    sceneElementsDescription: effectDescription,
+    desiredDurationInFrames: 6 * 30,
+    dimensions: { width: 1920, height: 1080 },
+  };
+
+  const { brief, briefId } = await import("~/server/services/animationDesigner.service")
+    .then((module) => module.generateAnimationDesignBrief(briefParams));
+
+  const { jobId, effect } = await generateComponent(
+    projectId,
+    brief,
+    assistantMessageId,
+    6,
+    30,
+    tempSceneId,
+    userId,
+    briefId
+  );
+
+  const duration = Date.now() - startTime;
+  chatLogger.tool(messageId, "generateRemotionComponent", `Generated component ${effect} (jobId: ${jobId}) in ${duration}ms`);
+
+  return {
+    message: `I'm generating a custom "${effect}" component based on your description. This might take a minute. You'll be able to add it to your timeline once it's ready.`,
+  };
+}
+
+export async function handlePlanScenes(
+  projectId: string,
+  userId: string,
+  scenePlan: any,
+  assistantMessageId: string,
+  emitter: Subject<any>
+): Promise<ToolCallResponse> {
+  const startTime = Date.now();
+  const messageId = assistantMessageId || "plan-scenes";
+
+  if (!scenePlan || !scenePlan.scenes || !Array.isArray(scenePlan.scenes)) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid scene plan format",
+    });
+  }
+
+  chatLogger.tool(messageId, "planVideoScenes", `Planning video with ${scenePlan.scenes.length} scenes for project ${projectId}`);
+
+  try {
+    for (let i = 0; i < scenePlan.scenes.length; i++) {
+      const scene = scenePlan.scenes[i];
+      if (!scene.id) {
+        chatLogger.tool(messageId, "planVideoScenes", `Scene at index ${i} is missing an ID`);
+      }
+      if (!scene.description) {
+        chatLogger.tool(messageId, "planVideoScenes", `Scene ${scene.id || i} is missing a description`);
+      }
+      if (typeof scene.durationInSeconds !== "number") {
+        chatLogger.tool(messageId, "planVideoScenes", `Scene ${scene.id || i} has invalid duration: ${scene.durationInSeconds}`);
+      }
+      if (!scene.effectType) {
+        chatLogger.tool(messageId, "planVideoScenes", `Scene ${scene.id || i} is missing an effect type`);
+      }
+    }
+  } catch (validationError) {
+    chatLogger.error(messageId, `Error validating scene plan`, { error: validationError });
+  }
+
+  const result = await handleScenePlan(
+    projectId,
+    userId,
+    scenePlan,
+    assistantMessageId,
+    db,
+    emitter
+  );
+
+  const duration = Date.now() - startTime;
+  chatLogger.tool(messageId, "planVideoScenes", `Scene planning completed in ${duration}ms with ${result.patches?.length || 0} patches`);
+
+  return result;
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -115,6 +115,7 @@ export enum StreamEventType {
   TOOL_RESULT = "toolResult",
   ERROR = "error",
   DONE = "done",
+  PROGRESS = "progress",
   RECONNECTED = "reconnected", // New event type for reconnection
 }
 
@@ -131,6 +132,7 @@ export type StreamEvent =
   | { type: "finalized"; status: "success" | "error" | "building" | "pending"; jobId?: string | null; eventId?: string }
   | { type: "scenePlan"; plan: any; status: "planning_complete"; eventId?: string }
   | { type: "sceneStatus"; sceneId: string; sceneIndex: number; status: "pending" | "building" | "success" | "error"; jobId?: string; error?: string; eventId?: string }
+  | { type: "progress"; message: string; eventId?: string }
   | { type: "reconnected"; lastEventId?: string; missedEvents: number; eventId?: string };
 
 /**


### PR DESCRIPTION
## Summary
- add new doc for sprint 24 detailing project 1 tickets
- start refactor of chatOrchestration service
- extract new llm and tool execution services
- add progress SSE events and recovery columns

## Testing
- `npm test` *(fails: jest is not defined)*
- `npm run lint` *(fails to lint many files)*
- `npm run typecheck` *(fails to compile TS)*