### PR TITLE
Add initial unit tests and document results

### DIFF
--- a/memory-bank/sprints/sprint24/progress.md
+++ b/memory-bank/sprints/sprint24/progress.md
@@ -66,5 +66,7 @@ As of the sprint initiation, we've identified the following status for the A2A s
 | Date | Update |
 |------|--------|
 | *Sprint Start* | Identified key issues and established sprint goals |
+| 2025-05-19 | Initial test run executed: 32 suites failing, 13 passing |
+| 2025-05-19 | Added EventBufferService and A2A utils tests, 15 suites passing |
 
 This document will be updated throughout the sprint to track progress and adjust priorities as needed.

--- a/memory-bank/sprints/sprint24/testing-status-update.md
+++ b/memory-bank/sprints/sprint24/testing-status-update.md
@@ -78,6 +78,25 @@ We've made significant progress on the BAZAAR-260 ticket to improve the testing 
 - Most A2A integration tests
 - Most agent-related tests
 
+### Latest Test Run (2025-05-19)
+
+Running `npm test` on a clean checkout yielded the following results:
+
+- **Test Suites**: 45 total, 13 passed, 32 failed
+- **Tests**: 167 total, 105 passed, 62 failed
+
+The majority of failures come from `jest is not defined` errors in agent tests
+and database connection issues in E2E tests. Passing suites include the simple
+app tests and basic integration tests for API routes and Drizzle utilities.
+
+### Test Run After Adding New Unit Tests (2025-05-19)
+
+Two new unit test suites were added for the `EventBufferService` and A2A
+utility functions. Running `npm test` again shows a slight improvement:
+
+- **Test Suites**: 47 total, 15 passed, 32 failed
+- **Tests**: 172 total, 110 passed, 62 failed
+
 ## Root Causes Identified
 
 1. **Module Resolution Issues**: ESM/CommonJS conflicts

--- a/src/server/services/__tests__/eventBuffer.service.test.ts
+++ b/src/server/services/__tests__/eventBuffer.service.test.ts
@@ -1,0 +1,40 @@
+// src/server/services/__tests__/eventBuffer.service.test.ts
+import { describe, it, expect } from '@jest/globals';
+import { EventBufferService } from '../eventBuffer.service';
+import { StreamEventType } from '~/types/chat';
+
+// Simplified event helper
+const createDelta = (content: string) => ({ type: 'delta' as const, content });
+
+describe('EventBufferService', () => {
+  it('replays missed events on reconnect', () => {
+    const service = new EventBufferService({ maxBufferSize: 10, bufferExpiryMs: 60000, reconnectWindowMs: 60000 });
+    service.registerClient('client1', 'msg1');
+
+    service.bufferEvent('msg1', createDelta('a'));
+    service.bufferEvent('msg1', createDelta('b'));
+    service.markDisconnected('client1');
+
+    const result = service.handleReconnection('client1');
+    expect(result).not.toBeNull();
+    expect(result!.events.length).toBe(2);
+    expect(result!.reconnectEvent.type).toBe('reconnected');
+    expect(result!.reconnectEvent.missedEvents).toBe(2);
+  });
+
+  it('drops old events when buffer is full', () => {
+    const service = new EventBufferService({ maxBufferSize: 2, bufferExpiryMs: 60000, reconnectWindowMs: 60000 });
+    service.registerClient('client2', 'msg2');
+
+    service.bufferEvent('msg2', createDelta('1'));
+    service.bufferEvent('msg2', createDelta('2'));
+    service.bufferEvent('msg2', createDelta('3')); // should remove the first event
+
+    service.markDisconnected('client2');
+    const result = service.handleReconnection('client2');
+    expect(result).not.toBeNull();
+    expect(result!.events.length).toBe(2);
+    expect(result!.events[0].event).toEqual(createDelta('2'));
+    expect(result!.events[1].event).toEqual(createDelta('3'));
+  });
+});

--- a/src/types/__tests__/a2a-utils.test.ts
+++ b/src/types/__tests__/a2a-utils.test.ts
@@ -1,0 +1,25 @@
+// src/types/__tests__/a2a-utils.test.ts
+import { describe, it, expect } from '@jest/globals';
+import { mapInternalToA2AState, mapA2AToInternalState, requiresUserInput } from '../a2a';
+
+describe('A2A state helpers', () => {
+  it('maps internal status to A2A state', () => {
+    expect(mapInternalToA2AState('pending')).toBe('submitted');
+    expect(mapInternalToA2AState('building')).toBe('working');
+    expect(mapInternalToA2AState('complete')).toBe('completed');
+    expect(mapInternalToA2AState('failed')).toBe('failed');
+  });
+
+  it('maps A2A state to internal status', () => {
+    expect(mapA2AToInternalState('submitted')).toBe('pending');
+    expect(mapA2AToInternalState('working')).toBe('generating');
+    expect(mapA2AToInternalState('completed')).toBe('complete');
+    expect(mapA2AToInternalState('failed')).toBe('failed');
+    expect(mapA2AToInternalState('unknown')).toBe('pending');
+  });
+
+  it('detects states that require user input', () => {
+    expect(requiresUserInput('input-required')).toBe(true);
+    expect(requiresUserInput('working')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add first unit tests for `EventBufferService` and A2A helper functions
- note new test run and results in testing status doc
- log progress entry in Sprint 24 progress doc

## Testing
- `npm test` *(fails: 32 suites failed, 15 passed)*
- `npm run lint`
- `npm run typecheck` *(fails)*