### PR TITLE
Update logging strategy docs

### DIFF
--- a/memory-bank/sprints/sprint24/progress.md
+++ b/memory-bank/sprints/sprint24/progress.md
@@ -66,5 +66,7 @@ As of the sprint initiation, we've identified the following status for the A2A s
 | Date | Update |
 |------|--------|
 | *Sprint Start* | Identified key issues and established sprint goals |
+| 2025-05-19 | Reviewed existing logs and added unified logging strategy guidance |
+| 2025-05-20 | Updated all Winston loggers to emit JSON and route to the Log Agent |
 
 This document will be updated throughout the sprint to track progress and adjust priorities as needed.

--- a/src/env.js
+++ b/src/env.js
@@ -66,6 +66,8 @@ export const env = createEnv({
    */
   client: {
     // NEXT_PUBLIC_CLIENTVAR: z.string(),
+    NEXT_PUBLIC_LOG_AGENT_URL: z.string().url().optional().default('http://localhost:3002'),
+    NEXT_PUBLIC_LOG_RUN_ID: z.string().optional(),
   },
 
   /**
@@ -97,6 +99,8 @@ export const env = createEnv({
     USE_MESSAGE_BUS: process.env.USE_MESSAGE_BUS,
     DISABLE_BACKGROUND_WORKERS: process.env.DISABLE_BACKGROUND_WORKERS,
     LOG_AGENT_URL: process.env.LOG_AGENT_URL,
+    NEXT_PUBLIC_LOG_AGENT_URL: process.env.NEXT_PUBLIC_LOG_AGENT_URL,
+    NEXT_PUBLIC_LOG_RUN_ID: process.env.NEXT_PUBLIC_LOG_RUN_ID,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -196,36 +196,60 @@ if (isServer) {
   // Simple console logger for client-side
   logger = createLogger({
     level: 'info',
-    format: consoleFormat,
+    format: fileFormat,
     transports: [
       new transports.Console({
-        format: consoleFormat
-      })
-    ]
+        format: consoleFormat,
+      }),
+    ],
   });
 
   // Create a separate A2A logger
   a2aLogger = createLogger({
     level: 'info',
-    format: consoleFormat,
+    format: fileFormat,
     defaultMeta: { a2a: true },
     transports: [
       new transports.Console({
-        format: consoleFormat
-      })
-    ]
+        format: consoleFormat,
+      }),
+    ],
   });
 
   // Create a separate components logger
   componentsLogger = createLogger({
     level: 'info',
-    format: consoleFormat,
+    format: fileFormat,
     defaultMeta: {},
     transports: [
       new transports.Console({
-        format: consoleFormat
-      })
-    ]
+        format: consoleFormat,
+      }),
+    ],
+  });
+
+  const clientRunId = process.env.NEXT_PUBLIC_LOG_RUN_ID || generateRunId();
+  const clientAgentUrl =
+    process.env.NEXT_PUBLIC_LOG_AGENT_URL ||
+    process.env.LOG_AGENT_URL ||
+    `http://localhost:${logAgentConfig.port}`;
+
+  addLogAgentTransport(logger, {
+    agentUrl: clientAgentUrl,
+    source: 'main-app',
+    runId: clientRunId,
+  });
+
+  addLogAgentTransport(a2aLogger, {
+    agentUrl: clientAgentUrl,
+    source: 'a2a-system',
+    runId: clientRunId,
+  });
+
+  addLogAgentTransport(componentsLogger, {
+    agentUrl: clientAgentUrl,
+    source: 'components-worker',
+    runId: clientRunId,
   });
 }
 


### PR DESCRIPTION
## Summary
- expand BAZAAR-261 logging strategy notes
- track sprint progress updates
- expose Log Agent env vars to the client
- route client loggers through Log Agent

## Testing
- `npm test --silent` *(fails: ReferenceError: jest is not defined)*
- `npm run lint --silent` *(fails: numerous ESLint errors)*
- `npm run typecheck` *(fails: TS errors in verify components and tests)*