### PR TITLE
Implement basic agent heartbeat

### DIFF
--- a/src/server/api/routers/a2a.ts
+++ b/src/server/api/routers/a2a.ts
@@ -88,6 +88,13 @@ export const a2aRouter = createTRPCRouter({
         });
       }
     }),
+
+  /**
+   * Get agent lifecycle statuses
+   */
+  getAgentStatuses: publicProcedure.query(() => {
+    return agentRegistry.getAgentStatuses();
+  }),
   
   /**
    * Get detailed information about a specific agent

--- a/src/server/services/a2a/__tests__/lifecycleManager.service.test.ts
+++ b/src/server/services/a2a/__tests__/lifecycleManager.service.test.ts
@@ -1,0 +1,32 @@
+// src/server/services/a2a/__tests__/lifecycleManager.service.test.ts
+import { BaseAgent, AgentLifecycleState } from '~/server/agents/base-agent';
+import { LifecycleManager } from '../lifecycleManager.service';
+import { TaskManager } from '../taskManager.service';
+
+class MockAgent extends BaseAgent {
+  constructor(name: string, tm: TaskManager) {
+    super(name, tm);
+  }
+  async processMessage() { return null; }
+}
+
+describe('LifecycleManager', () => {
+  const tm = TaskManager.getInstance();
+  const manager = LifecycleManager.getInstance();
+
+  beforeEach(() => {
+    manager.stopMonitoring();
+  });
+
+  it('tracks heartbeats and states', async () => {
+    const agent = new MockAgent('TestAgent', tm);
+    manager.registerAgent(agent);
+    await agent.init();
+    manager.startMonitoring(20);
+    expect(manager.getAgentStatuses()[0].state).toBe(AgentLifecycleState.Ready);
+    await new Promise(r => setTimeout(r, 30));
+    expect(manager.getAgentStatuses()[0].state).toBe(AgentLifecycleState.Ready);
+    agent.stop();
+    manager.stopMonitoring();
+  });
+});

--- a/src/server/services/a2a/agentRegistry.service.ts
+++ b/src/server/services/a2a/agentRegistry.service.ts
@@ -1,5 +1,6 @@
-import { BaseAgent } from "~/server/agents/base-agent";
+import { BaseAgent, type AgentLifecycleState } from "~/server/agents/base-agent";
 import type { AgentCard } from "~/types/a2a";
+import { lifecycleManager } from "./lifecycleManager.service";
 
 /**
  * AgentRegistry service
@@ -25,6 +26,7 @@ export class AgentRegistry {
    */
   public registerAgent(agent: BaseAgent): void {
     this.agents.set(agent.name.toLowerCase(), agent);
+    lifecycleManager.registerAgent(agent);
     console.log(`Registered agent: ${agent.name}`);
   }
   
@@ -59,6 +61,10 @@ export class AgentRegistry {
    */
   public getAllAgentCards(): AgentCard[] {
     return this.getAllAgents().map(agent => agent.getAgentCard());
+  }
+
+  public getAgentStatuses(): { name: string; state: AgentLifecycleState; lastHeartbeat: number }[] {
+    return lifecycleManager.getAgentStatuses();
   }
 }
 

--- a/src/server/services/a2a/lifecycleManager.service.ts
+++ b/src/server/services/a2a/lifecycleManager.service.ts
@@ -1,0 +1,72 @@
+// src/server/services/a2a/lifecycleManager.service.ts
+import { AgentLifecycleState, type BaseAgent } from "~/server/agents/base-agent";
+
+interface AgentInfo {
+  state: AgentLifecycleState;
+  lastHeartbeat: number;
+}
+
+export class LifecycleManager {
+  private static instance: LifecycleManager;
+  private agents: Map<string, AgentInfo> = new Map();
+  private monitorTimer: NodeJS.Timeout | null = null;
+
+  private constructor() {}
+
+  static getInstance(): LifecycleManager {
+    if (!LifecycleManager.instance) {
+      LifecycleManager.instance = new LifecycleManager();
+    }
+    return LifecycleManager.instance;
+  }
+
+  registerAgent(agent: BaseAgent): void {
+    const name = agent.getName();
+    this.agents.set(name, { state: AgentLifecycleState.Initializing, lastHeartbeat: Date.now() });
+  }
+
+  updateState(agentName: string, state: AgentLifecycleState): void {
+    const info = this.agents.get(agentName);
+    if (info) {
+      info.state = state;
+    } else {
+      this.agents.set(agentName, { state, lastHeartbeat: Date.now() });
+    }
+  }
+
+  recordHeartbeat(agentName: string): void {
+    const info = this.agents.get(agentName);
+    if (info) {
+      info.lastHeartbeat = Date.now();
+    }
+  }
+
+  getAgentStatuses(): { name: string; state: AgentLifecycleState; lastHeartbeat: number }[] {
+    return Array.from(this.agents.entries()).map(([name, info]) => ({
+      name,
+      state: info.state,
+      lastHeartbeat: info.lastHeartbeat,
+    }));
+  }
+
+  startMonitoring(interval = 10000): void {
+    if (this.monitorTimer) return;
+    this.monitorTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [name, info] of this.agents) {
+        if (now - info.lastHeartbeat > interval * 2 && info.state !== AgentLifecycleState.Error) {
+          info.state = AgentLifecycleState.Error;
+        }
+      }
+    }, interval);
+  }
+
+  stopMonitoring(): void {
+    if (this.monitorTimer) {
+      clearInterval(this.monitorTimer);
+      this.monitorTimer = null;
+    }
+  }
+}
+
+export const lifecycleManager = LifecycleManager.getInstance();


### PR DESCRIPTION
## Summary
- implement a `LifecycleManager` service for agent heartbeats
- track lifecycle state and heartbeats in `BaseAgent`
- expose agent statuses via registry and tRPC router
- add simple tests for lifecycle manager

## Testing
- `npm test` *(fails: CoordinatorAgent and other suites fail)*
- `npm run lint`
- `npm run typecheck`