### PR TITLE
Update ESM component docs

### DIFF
--- a/memory-bank/api-docs/custom-components-integration.md
+++ b/memory-bank/api-docs/custom-components-integration.md
@@ -1,3 +1,4 @@
+<!-- path: memory-bank/api-docs/custom-components-integration.md -->
 # Custom Components Integration
 
 ## Overview
@@ -77,6 +78,10 @@ const patch: Operation[] = [
   }
 ];
 ```
+
+### ESM Component Loading
+Custom components are now uploaded as ES modules. When a user inserts a component,
+`React.lazy` dynamically imports the module from `data.src` and renders the default export.
 
 ## Technical Details
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -100,6 +100,8 @@ The ESM component migration has been completed successfully:
 This work completes tickets BAZAAR-255, BAZAAR-256, BAZAAR-257, BAZAAR-258, and BAZAAR-260. The system now uses modern JavaScript module patterns and better integration with React's component model. 
 
 See [Sprint 25 Progress](/memory-bank/sprints/sprint25/progress.md) for details.
+### 2025-05-26: Documentation for ESM Components Updated
+- Added new developer guide and updated integration docs. See [Sprint 25 Progress](./sprints/sprint25/progress.md).
 
 ### 2024-05-23: Sprint 25 Started - ESM Component Migration
 

--- a/memory-bank/remotion/custom-components-guide.md
+++ b/memory-bank/remotion/custom-components-guide.md
@@ -1,63 +1,42 @@
+<!-- path: memory-bank/remotion/custom-components-guide.md -->
 # Creating Custom Components for Bazaar-vid Remotion Player
 
-This guide explains how to create custom components that properly render in the Bazaar-vid Remotion player.
+This guide has been updated for the ESM-based loading approach introduced in Sprint 25.
 
-## Common Issues and How to Fix Them
+## Common Issues
 
-From our debugging, we've identified several common issues that prevent components from properly rendering:
-
-1. **Syntax Errors in JSX Closing Tags**
-   - Extra semicolons after closing tags (`</div>;`)
-   - Improper nesting of JSX elements
-   - Unterminated JSX elements
-
-2. **Missing Global References**
-   - Not properly referencing React and Remotion
-   - Missing `window.__REMOTION_COMPONENT` assignment
-
-3. **Runtime Errors**
-   - Component errors not being caught/reported properly
-   - Missing outputUrl despite "ready" status
+- **Syntax Errors**: Ensure JSX tags are properly closed and nested.
+- **Missing Default Export**: The Player expects the component to be the module's default export.
+- **Runtime Errors**: Check the browser console and server logs if the component fails to load.
 
 ## Working Component Template
 
-Use this template as a starting point for creating custom components:
-
 ```tsx
-// Always use window.React reference
-const React = window.React;
-// Get AbsoluteFill from Remotion
-const { AbsoluteFill } = window.Remotion;
+import { AbsoluteFill } from 'remotion';
+import React from 'react';
 
-// Define your component props
-interface MyComponentProps {
+export interface MyComponentProps {
   color?: string;
   size?: number;
   text?: string;
 }
 
-// Create your component
-const MyComponent = ({ 
-  color = '#ff0000', 
+const MyComponent: React.FC<MyComponentProps> = ({
+  color = '#ff0000',
   size = 200,
-  text = 'Remotion Circle'
-}: MyComponentProps) => {
-  // Optional: Use React hooks
-  React.useEffect(() => {
-    console.log('Component mounted');
-    return () => console.log('Component unmounted');
-  }, []);
-
-  // Return your JSX - proper indentation and nesting!
-  return (
-    <AbsoluteFill style={{ backgroundColor: 'transparent' }}>
-      <div style={{
+  text = 'Remotion Circle',
+}) => (
+  <AbsoluteFill style={{ backgroundColor: 'transparent' }}>
+    <div
+      style={{
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
         height: '100%',
-      }}>
-        <div style={{
+      }}
+    >
+      <div
+        style={{
           width: size,
           height: size,
           borderRadius: size / 2,
@@ -67,120 +46,27 @@ const MyComponent = ({
           alignItems: 'center',
           color: 'white',
           fontWeight: 'bold',
-        }}>
-          {text}
-        </div>
+        }}
+      >
+        {text}
       </div>
-    </AbsoluteFill>
-  );
-};
+    </div>
+  </AbsoluteFill>
+);
 
-// IMPORTANT: This assignment is required for Remotion to find the component
-window.__REMOTION_COMPONENT = MyComponent;
+export default MyComponent;
 ```
 
 ## How Components Are Processed
 
-1. When you create a component, it's stored in the database with its TSX code
-2. When the component is built, the system:
-   - Preprocesses the TSX to fix common issues
-   - Compiles it with esbuild
-   - Uploads the compiled JS to R2 storage
-   - Sets the component status to "ready" and stores the outputUrl
-
-3. When you add the component to a video:
-   - The CustomScene component loads the JS from the outputUrl
-   - The JS is evaluated and the window.__REMOTION_COMPONENT is accessed
-   - The component is rendered in the Remotion player
+1. The component code is stored in the database as TSX.
+2. During build the code is compiled with esbuild to an ESM file and uploaded to R2 storage.
+3. When added to a video, `React.lazy` dynamically imports the module from the stored URL and renders the default export.
 
 ## Troubleshooting
 
-If your component isn't rendering correctly:
+1. **Check the Console Logs** – browser and server logs usually explain loading failures.
+2. **Use the Fix Script** – `npx tsx src/scripts/fix-component-syntax.ts <component-id>` can resolve common syntax problems.
+3. **Start from the Template** – if issues persist, copy the template above and adjust it incrementally.
 
-1. **Check the Console Logs**
-   - Look for errors in the browser console
-   - Check server logs for build errors
-
-2. **Use the Debug Button**
-   - The debug button will identify components that are marked as "ready" but missing outputUrl
-   - It will reset these to "pending" so they can be properly rebuilt
-
-3. **Use the Fix Script**
-   - We've created a script that can fix common syntax issues in components
-   - Run `npx tsx src/scripts/fix-component-syntax.ts <component-id>` to fix a component
-
-4. **Start from the Template**
-   - If you're having trouble, start from the template above
-
-## Common Gotchas
-
-1. **No Extra Semicolons**
-   - Don't add semicolons after JSX closing tags
-
-2. **Proper Nesting**
-   - Make sure your JSX elements are properly nested
-   - All opening tags must have corresponding closing tags
-
-3. **Required Assignment**
-   - You must assign your component to `window.__REMOTION_COMPONENT`
-   - This is how Remotion finds your component
-
-4. **Use window.React and window.Remotion**
-   - Always reference React and Remotion from the window object
-   - Our preprocessor will handle this for you if you follow the template
-
-5. **AbsoluteFill is Recommended**
-   - Use AbsoluteFill as the root element to properly fill the frame
-   - Ensures your component fills the entire composition
-
-6. **Don't Use Dynamic Imports**
-   - Stick to standard imports and references
-   - Avoid dynamic imports or require() statements
-
-## Example of a Working Component
-
-Here's a simple working component that adds a bouncing ball animation:
-
-```tsx
-const React = window.React;
-const { AbsoluteFill, useCurrentFrame, interpolate } = window.Remotion;
-
-const BouncingBall = ({ color = '#0066cc', size = 100 }) => {
-  const frame = useCurrentFrame();
-  
-  // Create a bouncing animation using interpolate
-  const y = interpolate(
-    frame % 60,
-    [0, 30, 60],
-    [0, 200, 0],
-    {
-      extrapolateLeft: 'clamp',
-      extrapolateRight: 'clamp'
-    }
-  );
-  
-  return (
-    <AbsoluteFill style={{ backgroundColor: 'transparent' }}>
-      <div style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        height: '100%',
-      }}>
-        <div style={{
-          width: size,
-          height: size,
-          borderRadius: size / 2,
-          backgroundColor: color,
-          transform: `translateY(${y}px)`,
-          transition: 'transform 0.1s ease-in-out',
-        }} />
-      </div>
-    </AbsoluteFill>
-  );
-};
-
-window.__REMOTION_COMPONENT = BouncingBall;
-```
-
-Follow these guidelines and your custom components should work properly in the Bazaar-vid Remotion player. 
+Follow these guidelines and your custom components should work properly in the Bazaar-vid Remotion player.

--- a/memory-bank/remotion/esm-component-development.md
+++ b/memory-bank/remotion/esm-component-development.md
@@ -1,0 +1,41 @@
+<!-- path: memory-bank/remotion/esm-component-development.md -->
+# Developer Guide: Creating ESM-Compatible Components
+
+This guide explains how to write custom Remotion components that comply with the new ESM-based loading mechanism introduced in Sprint 25.
+
+## 1. Module Structure
+
+- **Default Export**: Always export your component as the default export.
+- **Standard Imports**: Use regular `import` statements for React and Remotion. Do not rely on globals.
+- **No Global Assignments**: Remove any `window.__REMOTION_COMPONENT` or similar global side effects.
+
+```tsx
+// Example component
+import { AbsoluteFill } from 'remotion';
+import React from 'react';
+
+const MyEffect: React.FC = () => (
+  <AbsoluteFill style={{ background: 'white' }} />
+);
+
+export default MyEffect;
+```
+
+## 2. Bundling
+
+Components should be bundled using esbuild with `format: 'esm'` and `platform: 'browser'`. React and Remotion remain external so the output keeps the `import` statements.
+
+## 3. Loading in the Player
+
+Use `React.lazy` or the Remotion `lazyComponent` prop to load the module dynamically:
+
+```tsx
+const LazyComp = React.lazy(() => import(/* webpackIgnore: true */ url));
+```
+
+Wrap the component with `<Suspense>` when rendering.
+
+## 4. Testing
+
+Use `npm test` and the guidance in `testing/esm-component-testing.md` to verify that the compiled module exports a React component and loads correctly in the browser.
+

--- a/memory-bank/remotion/esm-migration-guide.md
+++ b/memory-bank/remotion/esm-migration-guide.md
@@ -72,4 +72,4 @@ This document explains how to refactor Bazaar‑Vid to follow the official Remot
 
 ## Summary
 
-Migrating to ESM modules aligns Bazaar‑Vid with Remotion’s recommended workflow. Components become standard JavaScript modules that can be lazily imported both in the browser and on the server, eliminating brittle global assignments and enabling better integration with the Player.
+Migrating to ESM modules aligns Bazaar‑Vid with Remotion’s recommended workflow. Components become standard JavaScript modules that can be lazily imported both in the browser and on the server, eliminating brittle global assignments and enabling better integration with the Player. For step‑by‑step authoring instructions see [Developer Guide: Creating ESM-Compatible Components](./esm-component-development.md).

--- a/memory-bank/sprints/sprint25/TODO.md
+++ b/memory-bank/sprints/sprint25/TODO.md
@@ -40,9 +40,9 @@
   - [ ] Implement server-side component validation
   - [ ] Create rendering safeguards
 
-- [ ] BAZAAR-261: Update documentation for ESM components
-  - [ ] Add developer guide for creating ESM-compatible components
-  - [ ] Update API documentation to reflect new component loading pattern
+- [x] BAZAAR-261: Update documentation for ESM components
+  - [x] Add developer guide for creating ESM-compatible components
+  - [x] Update API documentation to reflect new component loading pattern
 
 - [ ] BAZAAR-262: Performance testing for ESM components
   - [ ] Measure component load time before and after ESM migration

--- a/memory-bank/sprints/sprint25/progress.md
+++ b/memory-bank/sprints/sprint25/progress.md
@@ -164,3 +164,8 @@ Sprint 25 focuses on improvements to custom components, including:
   - Added comprehensive tests for ESM module format output
   - Added tests for different component export patterns (default export, named export)
   - Tested external dependency handling
+
+## May 26, 2025: BAZAAR-261 Documentation Updates
+- Created `esm-component-development.md` as a developer guide for writing ESM-compatible components.
+- Updated `custom-components-guide.md` to remove legacy global usage and show the new ESM pattern.
+- Updated API documentation (`custom-components-integration.md`) with details on React.lazy loading of ESM modules.


### PR DESCRIPTION
## Summary
- add new developer guide for creating ESM-compatible components
- update custom components guide for the ESM workflow
- refresh API documentation with lazy-loading section
- log documentation work in sprint 25 progress and mark TODO

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run type-check` *(fails: Missing script: "type-check")*
- `npm run lint` *(fails with many ESLint errors)*