### PR TITLE
Implement asset management utilities

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -11,6 +11,10 @@ work. When entries grow beyond that, move older sections to
 
 ## Recent Highlights
 
+**May 27, 2025: Asset Management Utilities Added**
+- Implemented `AssetAgentAdapter` and `LocalDiskAdapter` for handling uploaded and external assets.
+- Enables basic cataloging of images, audio and video for generated storyboards.
+
 **May 25, 2025: BAZAAR-257 Templates Updated**
 - `componentTemplate.ts` now exports components via `export default` and drops
   the global registration IIFE.

--- a/memory-bank/sprints/sprint26/progress.md
+++ b/memory-bank/sprints/sprint26/progress.md
@@ -26,6 +26,9 @@
     - AIStyleAgent: Creates consistent visual style for the video
     - AIAssetAgent: Identifies assets needed for the video
     - AICodeGenerator: Generates code for video scenes
+- ✅ Implemented asset management utilities
+  - Added AssetAgentAdapter with pluggable StorageAdapter
+  - Created LocalDiskAdapter for development usage
 
 ### Current Status
 
@@ -46,7 +49,6 @@ Each agent uses the OpenAI API to leverage AI capabilities for their specialized
 - Add a preview player to visualize the generated video
 - Create a saving mechanism to persist storyboards
 - Add the ability to edit generated storyboards
-- Implement asset management for generated videos
 
 ### Lessons Learned
 

--- a/src/agents/assets/assetAgentAdapter.ts
+++ b/src/agents/assets/assetAgentAdapter.ts
@@ -1,0 +1,112 @@
+// src/agents/assets/assetAgentAdapter.ts
+
+import { randomUUID } from 'crypto';
+import { StorageAdapter, StorageLocation } from './storageAdapter';
+import { logger } from '~/lib/logger';
+
+/** The storyboard schema's Asset shape */
+export interface StoryboardAsset {
+  id: string;
+  type: 'image' | 'video' | 'audio' | 'lottie' | '3d';
+  url: string;
+  alt?: string;
+  startTime?: number;
+  duration?: number;
+  loop?: boolean;
+  dimensions?: { width: number; height: number };
+}
+
+export type AssetCatalog = StoryboardAsset[];
+
+/** Inputs coming from UI / Orchestrator */
+export interface AssetHints {
+  uploadedFiles?: Array<{ tmpPath: string; filename: string; mime: string }>;
+  externalUrls?: string[];
+  visionExtracted?: string[];
+}
+
+export async function collectAssets(
+  hints: AssetHints,
+  storage: StorageAdapter,
+): Promise<AssetCatalog> {
+  const assets: AssetCatalog = [];
+
+  if (hints.uploadedFiles) {
+    for (const file of hints.uploadedFiles) {
+      const loc = await storage.uploadFile({
+        localPath: file.tmpPath,
+        contentType: file.mime,
+        originalFilename: file.filename,
+      });
+      assets.push(await toStoryboardAsset(loc));
+    }
+  }
+
+  if (hints.externalUrls) {
+    for (const url of hints.externalUrls) {
+      try {
+        const loc = await storage.importExternal(url);
+        assets.push(await toStoryboardAsset(loc));
+      } catch (err) {
+        logger.warn('External asset import failed', { url, err });
+      }
+    }
+  }
+
+  if (hints.visionExtracted) {
+    for (const url of hints.visionExtracted) {
+      if (assets.some(a => a.url === url)) continue;
+      const loc = await storage.importExternal(url).catch(() => null);
+      if (loc) assets.push(await toStoryboardAsset(loc));
+    }
+  }
+
+  return assets;
+}
+
+async function toStoryboardAsset(loc: StorageLocation): Promise<StoryboardAsset> {
+  const [typeMain] = loc.contentType.split('/');
+  let assetType: StoryboardAsset['type'] = 'image';
+
+  switch (typeMain) {
+    case 'image':
+      assetType = 'image';
+      break;
+    case 'video':
+      assetType = 'video';
+      break;
+    case 'audio':
+      assetType = 'audio';
+      break;
+    case 'model':
+      assetType = '3d';
+      break;
+    default:
+      if (loc.contentType.includes('lottie') || loc.path.endsWith('.json')) {
+        assetType = 'lottie';
+      }
+  }
+
+  const meta = await probeMedia(loc.publicUrl).catch(() => ({}));
+
+  return {
+    id: randomUUID(),
+    type: assetType,
+    url: loc.publicUrl,
+    alt: loc.originalFilename,
+    duration: meta.duration,
+    dimensions: meta.width ? { width: meta.width, height: meta.height } : undefined,
+  };
+}
+
+interface MediaMeta { width?: number; height?: number; duration?: number }
+async function probeMedia(url: string): Promise<MediaMeta> {
+  if (url.match(/\.(png|jpe?g|gif|webp)$/i)) {
+    const buffer = await fetch(url).then(r => r.arrayBuffer()).catch(() => null);
+    if (!buffer) return {};
+    const sharpMod = await import('sharp');
+    const meta = await sharpMod.default(Buffer.from(buffer)).metadata();
+    return { width: meta.width, height: meta.height };
+  }
+  return {};
+}

--- a/src/agents/assets/storageAdapter.ts
+++ b/src/agents/assets/storageAdapter.ts
@@ -1,0 +1,69 @@
+// src/agents/assets/storageAdapter.ts
+export interface UploadParams {
+  localPath: string;
+  contentType: string;
+  originalFilename: string;
+}
+
+export interface StorageLocation {
+  bucket: string;
+  path: string;
+  publicUrl: string;
+  contentType: string;
+  originalFilename: string;
+}
+
+export interface StorageAdapter {
+  uploadFile(p: UploadParams): Promise<StorageLocation>;
+  importExternal(url: string): Promise<StorageLocation>;
+}
+
+/**
+ * Simple local disk adapter used for development and testing.
+ * Files are copied to the /tmp/assets directory and served from there.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'crypto';
+
+const BASE_DIR = path.join(process.cwd(), 'tmp', 'assets');
+
+export class LocalDiskAdapter implements StorageAdapter {
+  async uploadFile(p: UploadParams): Promise<StorageLocation> {
+    await fs.mkdir(BASE_DIR, { recursive: true });
+    const id = randomUUID();
+    const ext = path.extname(p.originalFilename);
+    const filename = `${id}${ext}`;
+    const dest = path.join(BASE_DIR, filename);
+    await fs.copyFile(p.localPath, dest);
+    return {
+      bucket: 'local',
+      path: dest,
+      publicUrl: `file://${dest}`,
+      contentType: p.contentType,
+      originalFilename: p.originalFilename,
+    };
+  }
+
+  async importExternal(url: string): Promise<StorageLocation> {
+    await fs.mkdir(BASE_DIR, { recursive: true });
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${url}: ${res.status}`);
+    }
+    const contentType = res.headers.get('content-type') || 'application/octet-stream';
+    const buffer = await res.arrayBuffer();
+    const id = randomUUID();
+    const ext = path.extname(new URL(url).pathname) || '';
+    const filename = `${id}${ext}`;
+    const dest = path.join(BASE_DIR, filename);
+    await fs.writeFile(dest, Buffer.from(buffer));
+    return {
+      bucket: 'local',
+      path: dest,
+      publicUrl: `file://${dest}`,
+      contentType,
+      originalFilename: filename,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add AssetAgentAdapter and pluggable StorageAdapter with LocalDiskAdapter
- document asset management progress for Sprint 26
- mention new utilities in overall progress log

## Testing
- `npm test` *(fails: Jest encountered unexpected token and timeout errors)*
- `npm run type-check` *(script missing)*
- `npm run lint` *(fails with many lint errors)*