### PR TITLE
Implement sucrase compilation for video generator

### DIFF
--- a/memory-bank/sprints/sprint26/progress.md
+++ b/memory-bank/sprints/sprint26/progress.md
@@ -26,6 +26,9 @@
     - AIStyleAgent: Creates consistent visual style for the video
     - AIAssetAgent: Identifies assets needed for the video
     - AICodeGenerator: Generates code for video scenes
+- ✅ Added in-browser compilation using Sucrase and dynamic Remotion preview
+  - Components compile to ESM modules with React/Remotion globals
+  - RemotionPreview loads compiled scenes via React.lazy
 
 ### Current Status
 
@@ -42,7 +45,6 @@ Each agent uses the OpenAI API to leverage AI capabilities for their specialized
 
 ### Next Steps
 
-- Implement the actual component code compilation and rendering
 - Add a preview player to visualize the generated video
 - Create a saving mechanism to persist storyboards
 - Add the ability to edit generated storyboards


### PR DESCRIPTION
## Summary
- expose host React/Remotion globals and register shared modules in generate client
- compile TSX scene code to ESM with Sucrase
- dynamically load compiled module in `RemotionPreview`
- track blob URLs and refresh player
- document progress on Sprint 26

## Testing
- `npm run lint` *(fails: prefer-nullish-coalescing and other repo-wide issues)*
- `npm run type-check` *(script missing)*
- `npm test` *(fails to run jest suites)*